### PR TITLE
First cut at Spotify Web API

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@spotify/web-api-ts-sdk": "^1.1.0",
+    "@spotify/web-api-ts-sdk": "github:exastone/spotify-web-api-ts-sdk#astone-bug-fix",
     "@tauri-apps/api": "^1.4.0",
     "rc-progress": "^3.5.1",
     "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@spotify/web-api-ts-sdk':
-    specifier: ^1.1.0
-    version: 1.1.0
+    specifier: github:exastone/spotify-web-api-ts-sdk#astone-bug-fix
+    version: github.com/exastone/spotify-web-api-ts-sdk/1ed2359b1478e1866366174a4e214b4ab16433a4
   '@tauri-apps/api':
     specifier: ^1.4.0
     version: 1.4.0
@@ -502,10 +502,6 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /@spotify/web-api-ts-sdk@1.1.0:
-    resolution: {integrity: sha512-SDMduy1YOc86boPQQbjiTJVHhVDUOFTBKMovmBizEbURGVae1Cvswyd/gzSQQwE1FUDXTD4Y8nhn9XHDGvRENA==}
-    dev: false
-
   /@tauri-apps/api@1.4.0:
     resolution: {integrity: sha512-Jd6HPoTM1PZSFIzq7FB8VmMu3qSSyo/3lSwLpoapW+lQ41CL5Dow2KryLg+gyazA/58DRWI9vu/XpEeHK4uMdw==}
     engines: {node: '>= 14.6.0', npm: '>= 6.6.0', yarn: '>= 1.19.1'}
@@ -988,3 +984,9 @@ packages:
   /yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
     dev: true
+
+  github.com/exastone/spotify-web-api-ts-sdk/1ed2359b1478e1866366174a4e214b4ab16433a4:
+    resolution: {tarball: https://codeload.github.com/exastone/spotify-web-api-ts-sdk/tar.gz/1ed2359b1478e1866366174a4e214b4ab16433a4}
+    name: '@spotify/web-api-ts-sdk'
+    version: 1.1.0
+    dev: false

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,22 @@
 import { useEffect, useState } from "react";
 
 import "./App.css";
-// import Home from "./components/Home";
 import { Login } from "./components/Login";
-// import WebPlayback from "./components/WebPlayback";
 import WebPlayerV2 from "./components/WebPlayerV2";
-import Home from "./components/Home";
+import { AccessToken } from "@spotify/web-api-ts-sdk";
+import WebAPI from "./components/WebAPI";
+import WebAPIController from "./components/WebAPIController";
+// import WebPlayback from "./components/WebPlayback";
 
 function App() {
-  const [token, setToken] = useState("");
+  const [token, setToken] = useState<AccessToken>(
+    {
+      access_token: "",
+      token_type: "",
+      expires_in: 0,
+      refresh_token: "",
+      expires: 0
+    });
 
 
   useEffect(() => {
@@ -16,12 +24,18 @@ function App() {
     async function getToken() {
       const response = await fetch("http://localhost:8080/auth/token?user_id=0");
       const json = await response.json();
-      // console.log("response: " + json);
       if (json.access_token === undefined) {
         console.log("undefined");
-        setToken("");
+        setToken({
+          access_token: "",
+          token_type: "Bearer",
+          expires_in: 0,
+          refresh_token: "",
+          expires: 0
+        });
       } else {
-        setToken(json.access_token);
+        console.log(json)
+        setToken(json);
       }
     }
 
@@ -32,9 +46,14 @@ function App() {
 
   return (
     <>
-      {(token === "") ? <Login /> : <WebPlayerV2 token={token} />}
-      {/* {(token === "") ? <Login /> : <WebPlayback token={token} />} */}
-      {/* {(token === "") ? <Login /> : <Home token={token} />} */}
+      {token.access_token === "" ? <Login /> :
+        <div>
+          <WebPlayerV2 token={token} />
+          <WebAPI token={token}>
+            <WebAPIController />
+          </WebAPI>
+        </div>
+      }
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,18 +3,20 @@ import { useEffect, useState } from "react";
 import "./App.css";
 // import Home from "./components/Home";
 import { Login } from "./components/Login";
-import WebPlayback from "./components/WebPlayback";
+// import WebPlayback from "./components/WebPlayback";
+import WebPlayerV2 from "./components/WebPlayerV2";
+import Home from "./components/Home";
 
 function App() {
-  const [token, setToken] = useState('');
+  const [token, setToken] = useState("");
 
 
   useEffect(() => {
 
     async function getToken() {
-      const response = await fetch('http://localhost:8080/auth/token?user_id=0');
+      const response = await fetch("http://localhost:8080/auth/token?user_id=0");
       const json = await response.json();
-      console.log("response: " + json);
+      // console.log("response: " + json);
       if (json.access_token === undefined) {
         console.log("undefined");
         setToken("");
@@ -24,14 +26,15 @@ function App() {
     }
 
     getToken();
-    // console.log("test")
 
   }, []);
 
 
   return (
     <>
-      {(token === "") ? <Login /> : <WebPlayback token={token} />}
+      {(token === "") ? <Login /> : <WebPlayerV2 token={token} />}
+      {/* {(token === "") ? <Login /> : <WebPlayback token={token} />} */}
+      {/* {(token === "") ? <Login /> : <Home token={token} />} */}
     </>
   );
 }

--- a/src/components/PlaybackToggleButton.tsx
+++ b/src/components/PlaybackToggleButton.tsx
@@ -1,0 +1,22 @@
+interface PlaybackToggleButtonProps {
+    player: any; // Update with the correct type for the player instance
+}
+
+const PlaybackToggleButton: React.FC<PlaybackToggleButtonProps> = ({ player }) => {
+
+    const togglePlayback = () => {
+        if (player) {
+            player.togglePlay().then(() => {
+                console.log("Playback toggled");
+            }).catch((error: Error) => {
+                console.error("Error toggling playback", error);
+            });
+        }
+    };
+
+    return (
+        <button onClick={togglePlayback}>Toggle Playback</button>
+    );
+};
+
+export default PlaybackToggleButton;

--- a/src/components/WebAPI.tsx
+++ b/src/components/WebAPI.tsx
@@ -1,0 +1,29 @@
+import { AccessToken, SpotifyApi } from "@spotify/web-api-ts-sdk";
+import * as React from 'react';
+
+interface WebAPIProps {
+    token: AccessToken;
+    children: React.ReactNode;
+}
+
+// Create a context
+const SpotifyWebAPIContext = React.createContext<SpotifyApi | null>(null);
+
+const WebAPI: React.FC<WebAPIProps> = ({ token, children }) => {
+    const sdk = SpotifyApi.withAccessToken(
+        import.meta.env.VITE_SPOTIFY_CLIENT_ID,
+        token
+    );
+
+    console.log("[WebAPI component]")
+    console.log(sdk)
+
+    return (
+        <SpotifyWebAPIContext.Provider value={sdk}>
+            {children}
+        </SpotifyWebAPIContext.Provider>
+    );
+};
+
+export default WebAPI;
+export { SpotifyWebAPIContext };

--- a/src/components/WebAPIController.tsx
+++ b/src/components/WebAPIController.tsx
@@ -1,0 +1,73 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { SpotifyWebAPIContext } from './WebAPI';
+import { SpotifyApi } from "@spotify/web-api-ts-sdk";
+
+const getUserProfile = async (sdk: SpotifyApi | null, setUser: React.Dispatch<React.SetStateAction<any>>) => {
+    if (sdk) {
+        try {
+            const user = await sdk.currentUser.profile();
+            setUser(user);
+        } catch (error) {
+            console.error("Error getting user profile:", error);
+        }
+    }
+};
+
+const getDevices = async (sdk: SpotifyApi | null, setDevices: React.Dispatch<React.SetStateAction<{ id: string | null; name: string; is_active: boolean }[]>>) => {
+    if (sdk) {
+        try {
+            const response = await sdk.player.getAvailableDevices();
+            const deviceList = response.devices.map(device => ({
+                id: device.id,
+                name: device.name,
+                is_active: device.is_active
+            }));
+            console.log(deviceList);
+
+            setDevices(deviceList);
+        } catch (error) {
+            console.error("Error getting devices:", error);
+        }
+    }
+};
+
+const WebAPIController: React.FC = () => {
+    const sdk = useContext(SpotifyWebAPIContext);
+    const [user, setUser] = useState<any>(null);
+    const [devices, setDevices] = useState<{
+        id: string | null,
+        name: string,
+        is_active: boolean
+    }[]>([]);
+
+
+    useEffect(() => {
+        getUserProfile(sdk, setUser);
+        getDevices(sdk, setDevices);
+
+    }, [sdk]);
+
+    return (
+        <div>
+            <h2>WebAPIController</h2>
+            {user ? (
+                <div>
+                    <h3>{user.display_name}</h3>
+                    <p>{user.email}</p>
+                </div>
+            ) : (
+                <p>Loading...</p>
+            )}
+            <ul>
+                {devices.map((device, index) => (
+                    <li key={index}>
+                        {device.name} | ({device.id}) active: {device.is_active}
+                    </li>
+
+                ))}
+            </ul>
+        </div>
+    );
+};
+
+export default WebAPIController;

--- a/src/components/WebPlayerV2.tsx
+++ b/src/components/WebPlayerV2.tsx
@@ -1,39 +1,98 @@
-import { useEffect } from "react";
+// import { SpotifyApi } from "@spotify/web-api-ts-sdk";
+import { useEffect, useState } from "react";
+import PlaybackToggleButton from "./PlaybackToggleButton";
 
 interface WebPlayerV2Props {
   token: string;
 }
 
-const WebPlayerV2: React.FC<WebPlayerV2Props> = (token) => {
+
+const WebPlayerV2: React.FC<WebPlayerV2Props> = (props) => {
+  const [player, setPlayer] = useState<any>(undefined);
+  const [isConnected, setIsConnected] = useState<boolean>(false);
 
   useEffect(() => {
-    // Load the Spotify Web Playback SDK script dynamically
-    const scriptTag = document.createElement('script');
-    scriptTag.src = 'https://sdk.scdn.co/spotify-player.js';
-    scriptTag.async = true;
-    document.body.appendChild(scriptTag);
+    const script = document.createElement("script");
+    script.src = "https://sdk.scdn.co/spotify-player.js";
+    script.async = true;
+    document.body.appendChild(script);
 
-    // The callback function that will be called when the SDK is ready
     window.onSpotifyWebPlaybackSDKReady = () => {
-      const token = '[My access token]'; // Replace with your access token
-
-      // Initialize the player
-      const player = new Spotify.Player({
-        name: 'Web Playback SDK Quick Start Player',
-        getOAuthToken: (cb) => {
-          cb(token);
-        },
+      const player = new (window as any).Spotify.Player({
+        name: "Spotlight - Dev App",
+        getOAuthToken: (cb: (token: string) => void) => { cb(props.token); },
       });
 
-      // Add any event listeners and other player logic here
-    };
-  }, []);
+      setPlayer(player);
 
+      // Add event listeners
+      player.addListener("ready", ({ device_id }: { device_id: any }) => {
+        console.log("Ready with Device ID", device_id);
+        // console.log("Player", player);
+        setIsConnected(true);
+      });
+
+      player.addListener("not_ready", ({ device_id }: { device_id: any }) => {
+        console.log("Device ID has gone offline", device_id);
+        setIsConnected(false);
+      });
+
+      player.addListener('initialization_error', ({ message }: { message: Error }) => {
+        console.error(message);
+        setIsConnected(false);
+      });
+
+      player.addListener('authentication_error', ({ message }: { message: Error }) => {
+        console.error(message);
+        setIsConnected(false);
+      });
+
+      player.addListener('account_error', ({ message }: { message: Error }) => {
+        console.error(message);
+        setIsConnected(false);
+      });
+
+      player.addListener('autoplay_failed', () => {
+        console.log('Autoplay is not allowed by the browser autoplay rules');
+      });
+
+      player.addListener('player_state_changed', ({
+        position,
+        duration,
+        track_window: {
+          current_track
+        }, }:
+        {
+          position: number;
+          duration: number;
+          track_window: {
+            current_track: any;
+          };
+        }) => {
+        console.log('Currently Playing', current_track);
+        console.log('Position in Song', position);
+        console.log('Duration of Song', duration);
+      });
+
+
+
+      // Connect to the player
+      player.connect().then((success: boolean) => {
+        if (success) {
+          console.log("The Web Playback SDK successfully connected to Spotify!");
+        }
+      });
+    };
+
+  }, []);
 
   return (
     <div>
       <h1>Spotify Web Playback SDK Quick Start</h1>
+      {isConnected && <PlaybackToggleButton player={player} />}
       {/* Add any other JSX elements for your player UI */}
     </div>
   );
-}
+};
+
+export default WebPlayerV2

--- a/src/components/WebPlayerV2.tsx
+++ b/src/components/WebPlayerV2.tsx
@@ -1,9 +1,10 @@
 // import { SpotifyApi } from "@spotify/web-api-ts-sdk";
 import { useEffect, useState } from "react";
 import PlaybackToggleButton from "./PlaybackToggleButton";
+import { AccessToken } from "@spotify/web-api-ts-sdk";
 
 interface WebPlayerV2Props {
-  token: string;
+  token: AccessToken;
 }
 
 
@@ -20,7 +21,7 @@ const WebPlayerV2: React.FC<WebPlayerV2Props> = (props) => {
     window.onSpotifyWebPlaybackSDKReady = () => {
       const player = new (window as any).Spotify.Player({
         name: "Spotlight - Dev App",
-        getOAuthToken: (cb: (token: string) => void) => { cb(props.token); },
+        getOAuthToken: (cb: (token: string) => void) => { cb(props.token.access_token); },
       });
 
       setPlayer(player);
@@ -90,7 +91,6 @@ const WebPlayerV2: React.FC<WebPlayerV2Props> = (props) => {
     <div>
       <h1>Spotify Web Playback SDK Quick Start</h1>
       {isConnected && <PlaybackToggleButton player={player} />}
-      {/* Add any other JSX elements for your player UI */}
     </div>
   );
 };

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+    onSpotifyWebPlaybackSDKReady: () => void;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,21 @@
 import React from "react";
-import ReactDOM from "react-dom/client";
+// import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./styles.css";
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+import ReactDOM from 'react-dom';
+
+
+ReactDOM.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+  document.getElementById('root')
+);
+
+/* ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
 );
+ */


### PR DESCRIPTION
PR includes:

- Change ReactDOM.createRoot(...).render(...) to ReactDOM.render(...) to resolve issue with Spotify Web Playback SDK initialization
  - see: https://community.spotify.com/t5/Spotify-for-Developers/Spotify-Web-Playback-SDK-example-playback-buttons-don-t-work/m-p/5518053#M8262
- Change version of spotify/web-api-ts-sdk to forked version
  - see: https://github.com/spotify/spotify-web-api-ts-sdk/pull/60#issue-1878299930
- Refactor of token from string type to `AccessToken` type.
  - Backend was also updated to return additional json fields accepted by AccessToken type.
- Adds `WebAPI` component as react.context provider
- Adds `WebAPIController` example component as react.context consumer